### PR TITLE
Feature: Configurable MQTT Interval, Dynamic WiFi List & UI Menu Update

### DIFF
--- a/data/components/topMenu.js
+++ b/data/components/topMenu.js
@@ -10,13 +10,13 @@ class Header extends HTMLElement {
                 <div class=" topnav  card-4" id="topNav">
                     <a class=" " href="index.html" >Home</a>
                     <a class=" " href="setup.html">Setup</a>
+                    <a class=" " id="iocontrol-link" href="io_control.html">I/O Control</a>
                     <div class="dropdown-hover">
                        <a class=""> Web Apps</a>
                         <div class="dropdown-content ">
                             <a class=" " id="hockey-link" href="hockey/Scoreboard.html">Hockey</a>
                             <a class=" " id="boat-link" href="boat/index.html">Boat</a>
                             <a class=" " id="tides-link" href="tides.html">Tides</a>
-                            <a class=" " id="dashio-link" href="dashio.html">DashIO</a>
                         </div>
                     </div>
                     <a  class="" id="mqtt-link" href="mqtt.html">MQTTViewer</a>

--- a/data/setup.html
+++ b/data/setup.html
@@ -75,7 +75,9 @@
             
      
             <label class="inline" for="mqttport">PORT</label> 
-            <input type="text" id="mqttport" value="1883">
+            <input type="text" id="mqttport" value="1883"><br>
+            <label class="inline" for="mqttDataInterval">Data Send Interval (seconds):</label>
+            <input type="number" id="mqttDataInterval" name="mqttDataInterval" value="5" min="1">
         </div>
     </div>
 
@@ -160,8 +162,13 @@
 
         let buzzerEnabled = document.getElementById("buzzerEnabled").checked;
         let buzzerPin = parseInt(document.getElementById("buzzerPin").value);
+
+        let mqttDataIntervalSec = parseInt(document.getElementById("mqttDataInterval").value);
+        if (isNaN(mqttDataIntervalSec) || mqttDataIntervalSec < 1) {
+            mqttDataIntervalSec = 5;
+        }
     
-        const data = {  isMqtt, isConfigFromServer, ssid, pass, mqtturl, mqttport, gmtOffset_sec: gmtOffset, daylightOffset_sec: dstOffset, buzzer_enabled: buzzerEnabled, buzzer_pin: buzzerPin };
+        const data = {  isMqtt, isConfigFromServer, ssid, pass, mqtturl, mqttport, gmtOffset_sec: gmtOffset, daylightOffset_sec: dstOffset, buzzer_enabled: buzzerEnabled, buzzer_pin: buzzerPin, mqttDataIntervalSec: mqttDataIntervalSec };
 
         console.log( "Saving:", data)
         const options = { method: 'POST', headers: { 'Content-Type': 'application/json'}, body: JSON.stringify(data) }
@@ -187,6 +194,7 @@
         document.getElementById("dstOffset").value = dataJson["daylightOffset_sec"] !== undefined ? dataJson["daylightOffset_sec"] : 3600;
         document.getElementById("buzzerEnabled").checked = dataJson["buzzer_enabled"] || false;
         document.getElementById("buzzerPin").value = dataJson["buzzer_pin"] !== undefined ? dataJson["buzzer_pin"] : -1;
+        document.getElementById("mqttDataInterval").value = dataJson["mqttDataIntervalSec"] !== undefined ? dataJson["mqttDataIntervalSec"] : 5;
     }
 
   </script>

--- a/src/api/Esp32.h
+++ b/src/api/Esp32.h
@@ -59,6 +59,7 @@ namespace Esp32   //  ESP 32 configuration and helping methods
     bool spiffsMounted = false;
     bool buzzer_enabled_ = false;
     int configured_buzzer_pin_ = -1;
+    int mqtt_data_interval_seconds_ = 5; // Default interval 5 seconds
 
 
     const int ADC_Max = 4095;    
@@ -350,6 +351,11 @@ namespace Esp32   //  ESP 32 configuration and helping methods
         Mqtt::isEnabled =            configJson_["isMqtt"];     
         Esp32::isConfigFromServer =  configJson_["isConfigFromServer"]; 
         Mqtt::port =                configJson_["mqttport"]; // Changed Mqtt::port_ to Mqtt::port
+        Esp32::mqtt_data_interval_seconds_ = configJson_["mqttDataIntervalSec"] | 5;
+        if (Esp32::mqtt_data_interval_seconds_ < 1) {
+            Esp32::mqtt_data_interval_seconds_ = 1;
+        }
+        Serial.printf("Esp32: MQTT data send interval set to %d seconds.\n", Esp32::mqtt_data_interval_seconds_);
 
         String mqtturl =             configJson_["mqtturl"];
         
@@ -478,6 +484,7 @@ namespace Esp32   //  ESP 32 configuration and helping methods
                 configDoc["daylightOffset_sec"] = 3600;  // Default DST offset
                 configDoc["buzzer_enabled"] = false; // Default to false
                 configDoc["buzzer_pin"] = -1;      // Default to no pin / invalid
+                configDoc["mqttDataIntervalSec"] = 5; // Default value
                 Serial.println("setup -> Could not read Config file -> initializing new file");
                
                 if (saveConfig(configDoc)) Serial.println("setup -> Config file saved");   

--- a/src/api/WifiManager.cpp
+++ b/src/api/WifiManager.cpp
@@ -137,24 +137,24 @@ bool WifiManager::tryConnectToPreferredNetworks()
 
     if (!configFile) {    Serial.println("Failed to open config file");    return false;  }
 
+    Serial.println("SPIFFS mounted and config.txt found for SSID and credentials. Reading all entries.");
 
-        Serial.println("SPIFFS mounted and config.txt found for SSID and credentials");
+    preferredSsids_.clear();
+    preferredPasswords_.clear();
 
-    int i = 0;
-    while (configFile.available() && i < numPreferredNetworks) {
+    while (configFile.available()) {
         String line = configFile.readStringUntil('\n');
         line.trim();
         int separatorIndex = line.indexOf(':');
 
         if (separatorIndex != -1) {
-        preferredSsids_[i] = line.substring(0, separatorIndex).c_str();
-        preferredPasswords_[i] = line.substring(separatorIndex + 1).c_str();
-        i++;
+            preferredSsids_.push_back(line.substring(0, separatorIndex));
+            preferredPasswords_.push_back(line.substring(separatorIndex + 1));
         }
     }
     configFile.close();
 
-    for (int i = 0; i < numPreferredNetworks; i++) {
+    for (size_t i = 0; i < preferredSsids_.size(); i++) { // Iterate using vector's size
             const char* ssid = preferredSsids_[i].c_str();
             const char* password = preferredPasswords_[i].c_str();
 

--- a/src/api/WifiManager.h
+++ b/src/api/WifiManager.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <string> // Include the <string> header for std::string
+#include <vector> // Added for std::vector
 #include <WiFi.h>
 #include <ESPmDNS.h>
 
@@ -39,9 +40,9 @@ class WifiManager {
         void startAccessPoint();
     
         bool isWifiConnected_ = false;
-        const static int numPreferredNetworks = 3; // Update this based on your preferred SSID count  TODO:  ark.... lire le nbr de ligne dans config.txt? ou whatever?
-        String preferredSsids_[numPreferredNetworks];
-        String preferredPasswords_[numPreferredNetworks];
+        // const static int numPreferredNetworks = 3; // Removed
+        std::vector<String> preferredSsids_; // Changed to std::vector<String>
+        std::vector<String> preferredPasswords_; // Changed to std::vector<String>
 
         bool isAutoReconnect_ = false;
         bool isOTA_ = false;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -219,7 +219,7 @@ void loop()
                 if(Mqtt::isEnabled) sendHeartbeat();  
             }
 
-            if (millis() - startTime5 >= 5000UL)
+            if (millis() - startTime5 >= (static_cast<unsigned long>(Esp32::mqtt_data_interval_seconds_) * 1000UL))
             {
                 startTime5 = millis(); 
 


### PR DESCRIPTION
This commit implements several enhancements to configuration handling and user interface navigation:

1.  **Configurable MQTT Data Send Frequency:**
    *   You can now set the interval (in seconds) for sending MQTT data via the `setup.html` web page.
    *   This setting is stored in `esp32config.json` and utilized in `main.cpp`.
    *   Involves changes to `Esp32.h`, `data/setup.html`, and `main.cpp`.

2.  **Dynamic Preferred WiFi Network Handling:**
    *   `WifiManager` now dynamically reads all SSID/password pairs from `/config.txt`.
    *   Removed the hardcoded limit (`numPreferredNetworks`) and switched from static arrays to `std::vector<String>` for storing preferred networks.
    *   Involves changes to `WifiManager.h` and `WifiManager.cpp`.

3.  **Updated Navigation Menu:**
    *   Added a link to the new "I/O Control" page (`io_control.html`) in the top navigation menu.
    *   Removed a non-functional link to "DashIO" (`dashio.html`).
    *   Changes made in `data/components/topMenu.js`.

These improvements enhance the flexibility and usability of the iYak32 platform.