### PR TITLE
Further Fixes for Linker Errors and SYS_state Refactor

### DIFF
--- a/src/SystemState.h
+++ b/src/SystemState.h
@@ -1,0 +1,9 @@
+#pragma once
+
+enum class SYS_state {
+    BOOT,
+    DEVICES_CONFIG,
+    HEATUP,
+    FIRSTLOOP,
+    LOOP
+};

--- a/src/api/Esp32.h
+++ b/src/api/Esp32.h
@@ -2,6 +2,7 @@
 
 #include <Arduino.h> // For String, byte, etc.
 #include <ArduinoJson.h> // For JsonDocument (declaration needed for extern)
+#include "SystemState.h"  // Added for SYS_state enum visibility
 
 // Full header includes for classes used in Esp32 namespace extern declarations
 #include "WifiManager.h"    // Provides definition for WifiManager

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -3,6 +3,7 @@
 //#define BOAT
 
 #include <Arduino.h>
+#include "SystemState.h" // Added for SYS_state enum
 #include "api/Esp32.h"
 #include "api/Mqtt.h"    // Added for direct Mqtt namespace usage
 #include "api/devices/BMX280.h"  //  TODO : devrait etre encaps dans un device...   device = gestion IO = main config n feature focus
@@ -27,14 +28,14 @@ bool oledConnected = false;
 bool bmxConnected = false;
 
 //  STATE Machine - System 
-enum class SYS_state {
-    BOOT,
-    DEVICES_CONFIG,
-    HEATUP,
-    FIRSTLOOP,
-    LOOP
-};
-SYS_state state = SYS_state::BOOT;
+// enum class SYS_state { // Moved to SystemState.h
+//     BOOT,
+//     DEVICES_CONFIG,
+//     HEATUP,
+//     FIRSTLOOP,
+//     LOOP
+// };
+SYS_state state = SYS_state::BOOT; // Uses SYS_state from SystemState.h
 
 
 


### PR DESCRIPTION
This commit builds upon previous efforts to resolve "multiple definition" linker errors.

Key changes include:

1.  **Moved `SYS_state` Enum to Dedicated Header:**
    *   Created `src/SystemState.h` and moved the `enum class SYS_state` definition into it.
    *   Updated `src/main.cpp` and `src/api/Esp32.h` to include this new header.
    *   This centralizes the enum definition to prevent inconsistencies and potential linkage issues.

2.  **Verified Global `state` Variable Access:**
    *   Confirmed that `src/api/Esp32.cpp` and `src/api/WifiManager.cpp` do not define any `Esp32::state` variable nor do they directly access the global `state` from `main.cpp` in a way that would require new `extern` declarations or cause conflicts.

These changes, combined with the earlier Mqtt namespace refactoring, aim to resolve all previously reported "multiple definition" errors, especially the persistent one related to `Esp32::state`.