### PR TITLE
This commit applies fixes to resolve "multiple definition" linker err…

### DIFF
--- a/src/SystemState.h
+++ b/src/SystemState.h
@@ -7,3 +7,7 @@ enum class SYS_state {
     FIRSTLOOP,
     LOOP
 };
+
+// Accessor function declarations
+SYS_state get_current_system_state();
+void set_current_system_state(SYS_state new_state);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,9 +35,20 @@ bool bmxConnected = false;
 //     FIRSTLOOP,
 //     LOOP
 // };
-SYS_state state = SYS_state::BOOT; // Uses SYS_state from SystemState.h
+static SYS_state state = SYS_state::BOOT; // Uses SYS_state from SystemState.h, now static
 
+// Accessor functions for the static 'state' variable
+SYS_state get_current_system_state() {
+    return state;
+}
 
+void set_current_system_state(SYS_state new_state) {
+    // Optional: Log state changes centrally
+    // if (state != new_state) {
+    //    Serial.printf("System State: %d -> %d (via setter)\n", static_cast<int>(state), static_cast<int>(new_state));
+    // }
+    state = new_state;
+}
 
 
 void sendHeartbeat()
@@ -148,7 +159,7 @@ void loop()
             if(Esp32::isConfigFromServer)   Mqtt::mqttClient.publish("esp32/config", Esp32::DEVICE_NAME.c_str());  // Request IO config and profile from server
             
             Serial.println("BOOT done");
-            state = SYS_state::DEVICES_CONFIG;
+            set_current_system_state(SYS_state::DEVICES_CONFIG);
             break;
 
     case SYS_state::DEVICES_CONFIG:
@@ -168,7 +179,7 @@ void loop()
 #endif
 
             Serial.println("SENSORS & ALARMLib CONFIG done");
-            state = SYS_state::HEATUP;
+            set_current_system_state(SYS_state::HEATUP);
             break;
     
     case SYS_state::HEATUP:
@@ -179,7 +190,8 @@ void loop()
                 Serial.print("."); Serial.print(millis()); Serial.print("."); 
             }  
             else {
-                state = SYS_state::FIRSTLOOP; Serial.println(" On Fire! :)");
+                set_current_system_state(SYS_state::FIRSTLOOP);
+                Serial.println(" On Fire! :)");
                 }
             break;
 
@@ -196,7 +208,7 @@ void loop()
             //Lux::loop(); 
             
             Serial.println("FIRST LOOP done -- Let's roll!\n");
-            state = SYS_state::LOOP;
+            set_current_system_state(SYS_state::LOOP);
             break;
 
     case SYS_state::LOOP:       


### PR DESCRIPTION
…ors reported in the previous build.

Key Changes:

1.  **Refactored `Mqtt` Namespace for Proper Linkage:**
    *   Created `src/api/Mqtt.cpp` to host definitions of variables and functions/methods.
    *   Modified `src/api/Mqtt.h` to contain `extern` declarations and function/method prototypes.
    *   Corrected spelling of `Mqtt::subscription`.
    *   This resolves multiple definition errors related to the `Mqtt` namespace.

2.  **Addressed `Esp32::state` Multiple Definition Error:**
    *   Moved the `enum class SYS_state` definition to a new dedicated header file `src/SystemState.h`.
    *   Included `SystemState.h` in `main.cpp` and `src/api/Esp32.h` (and any other files that might require the `SYS_state` type definition).
    *   Changed the global `SYS_state state` variable in `main.cpp` to `static SYS_state state`, limiting its linkage to `main.cpp`.
    *   Added global accessor functions `get_current_system_state()` and `set_current_system_state(SYS_state new_state)` in `main.cpp` for controlled access to this static `state`.
    *   Declarations for these accessors were added to `SystemState.h`.
    *   Updated `main.cpp`'s loop to use `set_current_system_state()` for state transitions.
    *   Verified that `Esp32.h` and `Esp32.cpp` do not contain any conflicting definitions or declarations of `state` within the `Esp32` namespace.

These changes should resolve the linker errors and improve overall code structure and robustness. A clean build is recommended after pulling these changes.