### PR TITLE
I've made some changes to your code to help diagnose the persistent "…

### DIFF
--- a/src/SystemState.h
+++ b/src/SystemState.h
@@ -9,5 +9,5 @@ enum class SYS_state {
 };
 
 // Accessor function declarations
-SYS_state get_current_system_state();
-void set_current_system_state(SYS_state new_state);
+SYS_state get_current_system_state_temp();
+void set_current_system_state_temp(SYS_state new_state);

--- a/src/api/Esp32.cpp
+++ b/src/api/Esp32.cpp
@@ -27,6 +27,7 @@ namespace Esp32 {
     bool buzzer_enabled_ = false;
     int configured_buzzer_pin_ = -1;
     int mqtt_data_interval_seconds_ = 5;
+    int state_test_variable = 123; // Added for linker diagnostics
 
     // Function Definitions
     void setVerboseLog() { esp_log_level_set("*", ESP_LOG_DEBUG); }

--- a/src/api/Esp32.h
+++ b/src/api/Esp32.h
@@ -40,6 +40,7 @@ namespace Esp32 {
     extern bool buzzer_enabled_;
     extern int configured_buzzer_pin_;
     extern int mqtt_data_interval_seconds_;
+    extern int state_test_variable; // Added for linker diagnostics
 
     // Function Declarations
     void setVerboseLog();

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,19 +35,19 @@ bool bmxConnected = false;
 //     FIRSTLOOP,
 //     LOOP
 // };
-static SYS_state state = SYS_state::BOOT; // Uses SYS_state from SystemState.h, now static
+static SYS_state global_system_state_temp = SYS_state::BOOT; // Renamed
 
 // Accessor functions for the static 'state' variable
-SYS_state get_current_system_state() {
-    return state;
+SYS_state get_current_system_state_temp() { // Renamed
+    return global_system_state_temp;
 }
 
-void set_current_system_state(SYS_state new_state) {
+void set_current_system_state_temp(SYS_state new_state) { // Renamed
     // Optional: Log state changes centrally
-    // if (state != new_state) {
-    //    Serial.printf("System State: %d -> %d (via setter)\n", static_cast<int>(state), static_cast<int>(new_state));
+    // if (global_system_state_temp != new_state) {
+    //    Serial.printf("System State: %d -> %d (via setter)\n", static_cast<int>(global_system_state_temp), static_cast<int>(new_state));
     // }
-    state = new_state;
+    global_system_state_temp = new_state;
 }
 
 
@@ -151,7 +151,7 @@ void loop()
     Esp32::loop(); //  Handle OTA,  MQTT,  NTP,  etc...
     
 
-    switch(state) 
+    switch(global_system_state_temp) // Updated to use renamed static variable
     {
     case SYS_state::BOOT:
             
@@ -159,7 +159,7 @@ void loop()
             if(Esp32::isConfigFromServer)   Mqtt::mqttClient.publish("esp32/config", Esp32::DEVICE_NAME.c_str());  // Request IO config and profile from server
             
             Serial.println("BOOT done");
-            set_current_system_state(SYS_state::DEVICES_CONFIG);
+            set_current_system_state_temp(SYS_state::DEVICES_CONFIG); // Updated to use renamed setter
             break;
 
     case SYS_state::DEVICES_CONFIG:
@@ -179,7 +179,7 @@ void loop()
 #endif
 
             Serial.println("SENSORS & ALARMLib CONFIG done");
-            set_current_system_state(SYS_state::HEATUP);
+            set_current_system_state_temp(SYS_state::HEATUP); // Updated to use renamed setter
             break;
     
     case SYS_state::HEATUP:
@@ -190,7 +190,7 @@ void loop()
                 Serial.print("."); Serial.print(millis()); Serial.print("."); 
             }  
             else {
-                set_current_system_state(SYS_state::FIRSTLOOP);
+                set_current_system_state_temp(SYS_state::FIRSTLOOP); // Updated to use renamed setter
                 Serial.println(" On Fire! :)");
                 }
             break;
@@ -208,7 +208,7 @@ void loop()
             //Lux::loop(); 
             
             Serial.println("FIRST LOOP done -- Let's roll!\n");
-            set_current_system_state(SYS_state::LOOP);
+            set_current_system_state_temp(SYS_state::LOOP); // Updated to use renamed setter
             break;
 
     case SYS_state::LOOP:       


### PR DESCRIPTION
…multiple definition of Esp32::state" linker error.

Here's what I did:

1.  **Added `Esp32::state_test_variable`:**
    *   I declared `extern int Esp32::state_test_variable;` in `src/api/Esp32.h`.
    *   I defined `int Esp32::state_test_variable = 123;` in `src/api/Esp32.cpp`.
    *   This is a correctly linked namespaced variable to observe linker behavior.

2.  **Temporarily Renamed Global System State Variable:**
    *   In `src/main.cpp`, I renamed the `static SYS_state state` variable to `static SYS_state global_system_state_temp`.
    *   I renamed the accessor functions `get_current_system_state()` and `set_current_system_state()` to `get_current_system_state_temp()` and `set_current_system_state_temp()` respectively, and updated their definitions/declarations (in `main.cpp` and `src/SystemState.h`).
    *   I updated all uses of the state variable and its setter in `main.cpp`'s `loop()` to the new temporary names.
    *   This change aims to see if the specific name "state" being global in `main.cpp` was contributing to the linker's confusion.

These changes are for diagnostic purposes. The outcome of the next clean build and compilation will guide further steps.