### PR TITLE
Resolve Linker Errors, Refactor Buzzer & Hockey State

### DIFF
--- a/src/SystemState.h
+++ b/src/SystemState.h
@@ -9,5 +9,5 @@ enum class SYS_state {
 };
 
 // Accessor function declarations
-SYS_state get_current_system_state_temp();
-void set_current_system_state_temp(SYS_state new_state);
+SYS_state get_current_system_state();
+void set_current_system_state(SYS_state new_state);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -35,19 +35,19 @@ bool bmxConnected = false;
 //     FIRSTLOOP,
 //     LOOP
 // };
-static SYS_state global_system_state_temp = SYS_state::BOOT; // Renamed
+static SYS_state state = SYS_state::BOOT; // Reverted to original name
 
 // Accessor functions for the static 'state' variable
-SYS_state get_current_system_state_temp() { // Renamed
-    return global_system_state_temp;
+SYS_state get_current_system_state() { // Reverted to original name
+    return state;
 }
 
-void set_current_system_state_temp(SYS_state new_state) { // Renamed
+void set_current_system_state(SYS_state new_state) { // Reverted to original name
     // Optional: Log state changes centrally
-    // if (global_system_state_temp != new_state) {
-    //    Serial.printf("System State: %d -> %d (via setter)\n", static_cast<int>(global_system_state_temp), static_cast<int>(new_state));
+    // if (state != new_state) {
+    //    Serial.printf("System State: %d -> %d (via setter)\n", static_cast<int>(state), static_cast<int>(new_state));
     // }
-    global_system_state_temp = new_state;
+    state = new_state;
 }
 
 
@@ -151,7 +151,7 @@ void loop()
     Esp32::loop(); //  Handle OTA,  MQTT,  NTP,  etc...
     
 
-    switch(global_system_state_temp) // Updated to use renamed static variable
+    switch(state) // Reverted to original name
     {
     case SYS_state::BOOT:
             
@@ -159,7 +159,7 @@ void loop()
             if(Esp32::isConfigFromServer)   Mqtt::mqttClient.publish("esp32/config", Esp32::DEVICE_NAME.c_str());  // Request IO config and profile from server
             
             Serial.println("BOOT done");
-            set_current_system_state_temp(SYS_state::DEVICES_CONFIG); // Updated to use renamed setter
+            set_current_system_state(SYS_state::DEVICES_CONFIG); // Reverted to original setter
             break;
 
     case SYS_state::DEVICES_CONFIG:
@@ -179,7 +179,7 @@ void loop()
 #endif
 
             Serial.println("SENSORS & ALARMLib CONFIG done");
-            set_current_system_state_temp(SYS_state::HEATUP); // Updated to use renamed setter
+            set_current_system_state(SYS_state::HEATUP); // Reverted to original setter
             break;
     
     case SYS_state::HEATUP:
@@ -190,7 +190,7 @@ void loop()
                 Serial.print("."); Serial.print(millis()); Serial.print("."); 
             }  
             else {
-                set_current_system_state_temp(SYS_state::FIRSTLOOP); // Updated to use renamed setter
+                set_current_system_state(SYS_state::FIRSTLOOP); // Reverted to original setter
                 Serial.println(" On Fire! :)");
                 }
             break;
@@ -208,7 +208,7 @@ void loop()
             //Lux::loop(); 
             
             Serial.println("FIRST LOOP done -- Let's roll!\n");
-            set_current_system_state_temp(SYS_state::LOOP); // Updated to use renamed setter
+            set_current_system_state(SYS_state::LOOP); // Reverted to original setter
             break;
 
     case SYS_state::LOOP:       

--- a/src/www.h
+++ b/src/www.h
@@ -306,7 +306,7 @@ namespace www
             json += "\"time\":\""      + String(hockey.gettimeString()) + "\",";
             json += "\"period\":"  + String(hockey.getPeriod()) + ",";
             json += "\"periodLength\":"  + String(hockey.getPeriodLength()) + ",";
-            json += "\"gameStatus\":"  + String(Hockey::hockey.getCurrentGameState());
+            json += "\"gameStatus\":"  + String(hockey.getCurrentGameState());
             json += "}";
 
             request->send(200, "application/json", json);


### PR DESCRIPTION
This commit resolves persistent "multiple definition" linker errors and implements related structural improvements.

Key Changes:

1.  **Refactored Buzzer to Namespace Module (`BuzzerModule`):**
    *   The `Buzzer` class was transformed into a `BuzzerModule` namespace with its implementation and static internal variables moved to `src/api/devices/Buzzer.cpp`.
    *   This correctly scopes the buzzer's internal state variable (previously the cause of an `Esp32::state` or `Esp32::buzzer_state` multiple definition error when defined in the header).
    *   `Esp32.h` and `Esp32.cpp` were updated to remove the `Esp32::buzzer` object and use `BuzzerModule` functions.

2.  **Encapsulated Hockey Game State:**
    *   The `HOCKEY_state state` (or `hockey_state`) and `tictac` timer in `src/Hockey.h` were moved from namespace scope to become private member variables of the `Hockey` class, improving encapsulation.

3.  **Corrected Hockey State Access in `www.h`:**
    *   Fixed the method for accessing the Hockey game state in the `/hockey/scoreboard` endpoint in `src/www.h` to use the correct instance name (`hockey.getCurrentGameState()`).

4.  **Reverted Diagnostic Renaming of Global `state`:**
    *   After confirming successful compilation with the above fixes, the global system state variable in `main.cpp` was reverted from `global_system_state_temp` back to `static SYS_state state`.
    *   Accessor functions `get_current_system_state()` and `set_current_system_state()` and their declarations in `SystemState.h` were also reverted to their original names.

These changes collectively resolve the long-standing linker errors and improve the modularity and robustness of your codebase.