### PR TITLE
Fix ArduinoJson V7 Syntax & Stray Character in www.h

### DIFF
--- a/src/www.h
+++ b/src/www.h
@@ -237,7 +237,7 @@ namespace www
                     return;
                 } else {
                     Serial.println(F("Error: Failed to open /io_config.json for reading."));
-                    request->send(500, "application/json", "{\"status\":\"error", \"message\":\"Error reading I/O config file.\"}");
+                    request->send(500, "application/json", "{\"status\":\"error\", \"message\":\"Error reading I/O config file.\"}");
                 }
             } else {
                 // If no config file exists, send a default valid empty structure
@@ -270,7 +270,7 @@ namespace www
                     Serial.println(F("WWW: Received new I/O config via POST /api/io/config:"));
                     Serial.println(body_content_post_io);
 
-                    DynamicJsonDocument doc(2048); // Adjust size as needed
+                    JsonDocument doc; // V7 uses dynamic allocation by default
                     DeserializationError error = deserializeJson(doc, body_content_post_io);
                     body_content_post_io = ""; // Clear static buffer
 


### PR DESCRIPTION
This commit addresses several compilation errors and deprecation warnings primarily related to ArduinoJson V7 syntax and a minor string literal error.

1.  **Corrected Stray Backslash in `www.h`:**
    *   Fixed a malformed string literal in an error response within the `GET /api/io/config` handler in `src/www.h`. This resolved a "stray ''" error and a related `request->send()` overload issue.

2.  **Updated ArduinoJson V6 to V7 Syntax in `Esp32.cpp`:**
    *   In `Esp32::applyIOConfiguration()`: Changed `doc["io_pins"].as<JsonArray>()` to use `JsonVariantConst` with `isNull()` and `is<JsonArray>()` checks for safer parsing, and then `as<JsonArrayConst>()`. Iteration uses `JsonObjectConst`.
    *   In `Esp32::loadAndApplyIOConfig()`: Changed `StaticJsonDocument<2048>` to `JsonDocument`.
    *   In `Esp32::getIOStatusJsonString()`: Changed `StaticJsonDocument<1024>` to `JsonDocument`. Updated `createNestedArray("key")` to `doc[key].to<JsonArray>()` and `JsonArray::createNestedObject()` to `array.add<JsonObject>()`.

3.  **Updated ArduinoJson V6 to V7 Syntax in `www.h`:**
    *   In the `POST /api/io/config` handler, changed `DynamicJsonDocument doc(2048)` to `JsonDocument doc;`.

These changes resolve previously reported compilation errors and ArduinoJson V7 deprecation warnings, ensuring the code uses the correct and current library APIs.