### PR TITLE
Refactor: Make WifiManager::getWiFiStrength() Non-Blocking

### DIFF
--- a/src/api/WifiManager.h
+++ b/src/api/WifiManager.h
@@ -29,8 +29,9 @@ class WifiManager {
         void setSSID(String ssid);
         String getPASS();
         void setPASS(String pass);
-        int getWiFiStrength(int points = 10); 
+        int getWiFiStrength(); // Removed points parameter
         void relaunchOTA();
+        void setRssiMaxSamples(byte samples); // Setter for max_rssi_samples_
 
     private:
         void setupOTA();
@@ -50,4 +51,10 @@ class WifiManager {
         IPAddress ipAddress_;
         String ssid_; // Stays as is (already has underscore, though not strictly private style, but per instructions)
         String password_; // Renamed from pass_
+
+        // For non-blocking RSSI averaging
+        std::vector<long> rssi_samples_;
+        byte max_rssi_samples_ = 10;
+        unsigned long last_rssi_sample_time_ = 0;
+        long current_avg_rssi_ = 0;
 };


### PR DESCRIPTION
This commit refactors the `WifiManager::getWiFiStrength()` method to be non-blocking.

- Removed the blocking loop with `delay()` from `getWiFiStrength()`.
- Added logic to `WifiManager::loop()` to periodically sample WiFi.RSSI().
- RSSI samples are stored in a std::vector, acting as a sliding window.
- `current_avg_rssi_` is continuously updated with the average of these samples.
- `getWiFiStrength()` now returns the latest `current_avg_rssi_` immediately.
- Added `setRssiMaxSamples()` to allow configuration of the sample window size.

This change improves system responsiveness by preventing `getWiFiStrength()` from blocking the main loop or other operations. This also addresses a previous TODO item.

This commit should be combined with previous work on the Generic I/O UI and other fixes for full testing.