### PR TITLE
I've set the default buzzer pin to 14.

### DIFF
--- a/src/api/Esp32.cpp
+++ b/src/api/Esp32.cpp
@@ -218,7 +218,7 @@ namespace Esp32 {
         }
 
         Esp32::buzzer_enabled_ = configJson_["buzzer_enabled"] | false;
-        Esp32::configured_buzzer_pin_ = configJson_["buzzer_pin"] | -1;
+        Esp32::configured_buzzer_pin_ = configJson_["buzzer_pin"] | 14;
 
         if (Esp32::buzzer_enabled_ && Esp32::configured_buzzer_pin_ != -1) {
             BuzzerModule::init(Esp32::configured_buzzer_pin_); // Changed to BuzzerModule
@@ -345,7 +345,7 @@ namespace Esp32 {
                 configDoc["gmtOffset_sec"] = -18000;
                 configDoc["daylightOffset_sec"] = 3600;
                 configDoc["buzzer_enabled"] = false;
-                configDoc["buzzer_pin"] = -1;
+                configDoc["buzzer_pin"] = 14;
                 configDoc["mqttDataIntervalSec"] = 5;
                 Serial.println("setup -> Could not read Config file -> initializing new file");
 


### PR DESCRIPTION
I modified `Esp32.cpp` to change the default buzzer pin from -1 (unconfigured) to 14.

This change affects two areas:
1. When reading the configuration (in `executeJsonConfig`), if 'buzzer_pin' is not specified in 'esp32config.json', it will now default to 14.
2. If 'esp32config.json' is not found and a new default configuration is generated (in `setup`), the 'buzzer_pin' will be set to 14.

This ensures that a functional default buzzer pin is active unless explicitly overridden by your configuration.