### PR TITLE
feat(hockey): Make game event durations configurable via Web GUI

### DIFF
--- a/data/hockey/Hockey.html
+++ b/data/hockey/Hockey.html
@@ -69,6 +69,42 @@
     <p>Current Value: <span id="periodLenghtValue">0</span></p>
   </div>
 
+    <!-- Intro Duration -->
+    <div class="form-container">
+      <h3>Intro Duration</h3>
+      <label for="introDurationTicks">Intro Duration (ticks):</label>
+      <input type="number" id="introDurationTicks" placeholder="Enter ticks value">
+      <button class="button" onclick="setIntroDurationGui()">Set</button>
+      <p>Current Value: <span id="currentIntroDurationTicks">0</span> ticks</p>
+    </div>
+
+    <!-- Goal Celebration Duration -->
+    <div class="form-container">
+      <h3>Goal Celebration Duration</h3>
+      <label for="goalCelebrationTicks">Goal Celebration (ticks):</label>
+      <input type="number" id="goalCelebrationTicks" placeholder="Enter ticks value">
+      <button class="button" onclick="setGoalCelebrationDurationGui()">Set</button>
+      <p>Current Value: <span id="currentGoalCelebrationTicks">0</span> ticks</p>
+    </div>
+
+    <!-- Puck Drop Duration -->
+    <div class="form-container">
+      <h3>Puck Drop Duration</h3>
+      <label for="puckDropTicks">Puck Drop (ticks):</label>
+      <input type="number" id="puckDropTicks" placeholder="Enter ticks value">
+      <button class="button" onclick="setPuckDropDurationGui()">Set</button>
+      <p>Current Value: <span id="currentPuckDropTicks">0</span> ticks</p>
+    </div>
+
+    <!-- Period Intermission Duration -->
+    <div class="form-container">
+      <h3>Period Intermission Duration</h3>
+      <label for="periodIntermissionTicks">Period Intermission (ticks):</label>
+      <input type="number" id="periodIntermissionTicks" placeholder="Enter ticks value">
+      <button class="button" onclick="setPeriodIntermissionDurationGui()">Set</button>
+      <p>Current Value: <span id="currentPeriodIntermissionTicks">0</span> ticks</p>
+    </div>
+
   <h5>IO Status</h5>
   <p>Analog Pin 34: <span id='pin34'></span></p>
   <p>Analog Pin 39: <span id='pin39'></span></p>
@@ -139,6 +175,49 @@
         .catch(error => console.error('Error:', error));
     }
 
+    function setIntroDurationGui() {
+      const ticks = document.getElementById('introDurationTicks').value;
+      fetch(`/hockey/setIntroDuration?ticks=${ticks}`, { method: 'POST' })
+        .then(response => response.text())
+        .then(data => {
+          console.log(data);
+          updateScoreboard(); // Refresh scoreboard to show new value
+        })
+        .catch(error => console.error('Error setting intro duration:', error));
+    }
+
+    function setGoalCelebrationDurationGui() {
+      const ticks = document.getElementById('goalCelebrationTicks').value;
+      fetch(`/hockey/setGoalCelebrationDuration?ticks=${ticks}`, { method: 'POST' })
+        .then(response => response.text())
+        .then(data => {
+          console.log(data);
+          updateScoreboard();
+        })
+        .catch(error => console.error('Error setting goal celebration duration:', error));
+    }
+
+    function setPuckDropDurationGui() {
+      const ticks = document.getElementById('puckDropTicks').value;
+      fetch(`/hockey/setPuckDropDuration?ticks=${ticks}`, { method: 'POST' })
+        .then(response => response.text())
+        .then(data => {
+          console.log(data);
+          updateScoreboard();
+        })
+        .catch(error => console.error('Error setting puck drop duration:', error));
+    }
+
+    function setPeriodIntermissionDurationGui() {
+      const ticks = document.getElementById('periodIntermissionTicks').value;
+      fetch(`/hockey/setPeriodIntermissionDuration?ticks=${ticks}`, { method: 'POST' })
+        .then(response => response.text())
+        .then(data => {
+          console.log(data);
+          updateScoreboard();
+        })
+        .catch(error => console.error('Error setting period intermission duration:', error));
+    }
     function setPeriodLength() {
       const minutes = document.getElementById(`periodLength`).value;
       fetch(`setPeriodLength?minutes=${minutes}`, { method: 'POST' })
@@ -211,6 +290,19 @@
                 // Also update the input fields themselves
                 document.getElementById('leftDelta').value = data.leftDeltaValue !== undefined ? data.leftDeltaValue : '';
                 document.getElementById('rightDelta').value = data.rightDeltaValue !== undefined ? data.rightDeltaValue : '';
+
+                // Add updates for new duration parameters
+                document.getElementById('currentIntroDurationTicks').innerText = data.introDurationTicks ?? "0";
+                document.getElementById('introDurationTicks').value = data.introDurationTicks ?? "";
+
+                document.getElementById('currentGoalCelebrationTicks').innerText = data.goalCelebrationTicks ?? "0";
+                document.getElementById('goalCelebrationTicks').value = data.goalCelebrationTicks ?? "";
+
+                document.getElementById('currentPuckDropTicks').innerText = data.puckDropTicks ?? "0";
+                document.getElementById('puckDropTicks').value = data.puckDropTicks ?? "";
+
+                document.getElementById('currentPeriodIntermissionTicks').innerText = data.periodIntermissionTicks ?? "0";
+                document.getElementById('periodIntermissionTicks').value = data.periodIntermissionTicks ?? "";
             })
             .catch(error => {
                 console.error('Error fetching scoreboard:', error);

--- a/src/www.h
+++ b/src/www.h
@@ -376,6 +376,46 @@ namespace www
             request->send(200, "text/html", "ESP32 Hockey Timer Interface");
         }); 
 
+        server.on("/hockey/setIntroDuration", HTTP_POST, [](AsyncWebServerRequest *request){
+            if (request->hasParam("ticks")) {
+                String ticksStr = request->getParam("ticks")->value();
+                hockey.setIntroDurationTicks(ticksStr.toInt());
+                request->send(200, "text/plain", "Intro duration set to " + ticksStr + " ticks.");
+            } else {
+                request->send(400, "text/plain", "Missing 'ticks' parameter.");
+            }
+        });
+
+        server.on("/hockey/setGoalCelebrationDuration", HTTP_POST, [](AsyncWebServerRequest *request){
+            if (request->hasParam("ticks")) {
+                String ticksStr = request->getParam("ticks")->value();
+                hockey.setGoalCelebrationTicks(ticksStr.toInt());
+                request->send(200, "text/plain", "Goal celebration duration set to " + ticksStr + " ticks.");
+            } else {
+                request->send(400, "text/plain", "Missing 'ticks' parameter.");
+            }
+        });
+
+        server.on("/hockey/setPuckDropDuration", HTTP_POST, [](AsyncWebServerRequest *request){
+            if (request->hasParam("ticks")) {
+                String ticksStr = request->getParam("ticks")->value();
+                hockey.setPuckDropTicks(ticksStr.toInt());
+                request->send(200, "text/plain", "Puck drop duration set to " + ticksStr + " ticks.");
+            } else {
+                request->send(400, "text/plain", "Missing 'ticks' parameter.");
+            }
+        });
+
+        server.on("/hockey/setPeriodIntermissionDuration", HTTP_POST, [](AsyncWebServerRequest *request){
+            if (request->hasParam("ticks")) {
+                String ticksStr = request->getParam("ticks")->value();
+                hockey.setPeriodIntermissionTicks(ticksStr.toInt());
+                request->send(200, "text/plain", "Period intermission duration set to " + ticksStr + " ticks.");
+            } else {
+                request->send(400, "text/plain", "Missing 'ticks' parameter.");
+            }
+        });
+
         server.on("/hockey/scoreboard", HTTP_GET,[](AsyncWebServerRequest *request){
            /* unsigned long elapsed = isPaused ? pausedTime : millis() - startTime;
             unsigned int minutes = (elapsed / 1000) / 60;
@@ -393,10 +433,17 @@ namespace www
             json += "\"scoreRight\":" + String(hockey.getScoreRight()) + ",";
             json += "\"time\":\""      + String(hockey.gettimeString()) + "\",";
             json += "\"period\":"  + String(hockey.getPeriod()) + ",";
-            json += "\"periodLength\":"  + String(hockey.getPeriodLength()) + ",";
-            json += "\"gameStatus\":"  + String(hockey.getCurrentGameState()) + ","; // Add comma
+            json += "\"periodLength\":"  + String(hockey.getPeriodLength()) + ","; // This is in minutes
+            json += "\"gameStatus\":"  + String(hockey.getCurrentGameState()) + ",";
             json += "\"leftDeltaValue\":" + String(hockey.getLeftDelta()) + ",";
-            json += "\"rightDeltaValue\":" + String(hockey.getRightDelta());
+            json += "\"rightDeltaValue\":" + String(hockey.getRightDelta()) + ","; // Added comma
+
+            // Add new duration fields (as ticks)
+            json += "\"introDurationTicks\":" + String(hockey.getIntroDurationTicks()) + ",";
+            json += "\"goalCelebrationTicks\":" + String(hockey.getGoalCelebrationTicks()) + ",";
+            json += "\"puckDropTicks\":" + String(hockey.getPuckDropTicks()) + ",";
+            json += "\"periodIntermissionTicks\":" + String(hockey.getPeriodIntermissionTicks()); // No comma for the last item
+
             json += "}";
 
             request->send(200, "application/json", json);


### PR DESCRIPTION
Introduces the ability to configure various hockey game event durations through the web interface (Hockey.html). This provides you with flexibility to customize the game experience.

The following durations are now configurable (as tick counts):
- Intro animation duration
- Goal celebration duration
- Puck drop sequence duration
- Period intermission duration

Changes include:
- Modified `src/Hockey.h`:
    - Replaced the hardcoded `GOAL_DELAY` constant with new private member variables for each configurable duration, initialized with default tick values.
    - Added public setter and getter methods for these durations.
    - Updated game state logic in the `loop()` method to use these new variables.
- Modified `src/www.h`:
    - Added new HTTP POST endpoints to allow setting each new duration from the web GUI (e.g., /hockey/setIntroDuration).
    - Updated the `/hockey/scoreboard` GET endpoint to include the current values of these new durations in its JSON response.
- Modified `data/hockey/Hockey.html`:
    - Added new HTML sections with input fields and "Set" buttons for each configurable duration.
    - Implemented JavaScript functions to send the new duration values to the server via the new POST endpoints.
    - Updated the `updateScoreboard()` JavaScript function to display the current values of these durations, populating both the display spans and the input fields.

The firmware compiles successfully with these changes. Manual testing of the GUI and game behavior is recommended to ensure all durations function as expected.