### PR TITLE
feat: Implement hockey sounds and update buzzer config

### DIFF
--- a/src/Hockey.h
+++ b/src/Hockey.h
@@ -198,6 +198,7 @@ namespace Hockey
                         if(time <= 0) {
                             time = 0;
                             period++;
+                            BuzzerModule::setMode(BuzzerModule::ePERIOD_BELL); // Play end-of-period bell
                             current_game_state_ = HOCKEY_state::ePERIOD_BELL; // Use current_game_state_
                         }
                         
@@ -307,6 +308,7 @@ namespace Hockey
             tictac_ = 0; // Use tictac_
             time = periodLength;
             Serial.println(F("Game RESET."));
+            BuzzerModule::setMode(BuzzerModule::eINTRO); // Play intro sound
             current_game_state_ = HOCKEY_state::eINTRO; // Use current_game_state_
         }
 

--- a/src/api/Esp32.cpp
+++ b/src/api/Esp32.cpp
@@ -217,8 +217,10 @@ namespace Esp32 {
             if(hourglass.setupTimeSync()) hourglass.getDateTimeString(true);
         }
 
-        Esp32::buzzer_enabled_ = configJson_["buzzer_enabled"] | false;
+        Esp32::buzzer_enabled_ = configJson_["buzzer_enabled"] | true;
+        if (configJson_["buzzer_enabled"].isNull()) { Esp32::configJson_["buzzer_enabled"] = true; }
         Esp32::configured_buzzer_pin_ = configJson_["buzzer_pin"] | 14;
+        if (configJson_["buzzer_pin"].isNull()) { Esp32::configJson_["buzzer_pin"] = 14; }
 
         if (Esp32::buzzer_enabled_ && Esp32::configured_buzzer_pin_ != -1) {
             BuzzerModule::init(Esp32::configured_buzzer_pin_); // Changed to BuzzerModule
@@ -344,7 +346,7 @@ namespace Esp32 {
                 configDoc["profileName"] = "default_ESP32";
                 configDoc["gmtOffset_sec"] = -18000;
                 configDoc["daylightOffset_sec"] = 3600;
-                configDoc["buzzer_enabled"] = false;
+                configDoc["buzzer_enabled"] = true;
                 configDoc["buzzer_pin"] = 14;
                 configDoc["mqttDataIntervalSec"] = 5;
                 Serial.println("setup -> Could not read Config file -> initializing new file");


### PR DESCRIPTION
This commit introduces several enhancements to the buzzer and hockey mode:

1.  Added sounds for hockey game events:
    - An intro sound (siren) now plays when the hockey game is reset (`HOCKEY_state::eINTRO`).
    - An end-of-period bell (two short beeps) now plays when the period timer expires.
    - Goal sounds were previously implemented.

2.  Updated buzzer configuration:
    - The `buzzer_enabled` setting in `esp32config.json` now defaults to `true` if the key is missing from the file or when a new default configuration file is generated.
    - The `Esp32::configJson_` object in memory is updated to reflect these applied defaults, ensuring the `/data` endpoint and thus `setup.html` accurately display the buzzer's enabled state.

3.  Removed prior diagnostic `Serial.print` statements related to buzzer debugging.