### PR TITLE
feat: Implement Basic Mode with 3 buttons, LEDs, and sounds

### DIFF
--- a/data/io_config.json
+++ b/data/io_config.json
@@ -1,0 +1,52 @@
+{
+  "io_pins": [
+    {
+      "gpio": 12,
+      "label": "Button1",
+      "mode": "INPUT_PULLUP",
+      "type": "DIGITAL",
+      "initial_state": "",
+      "graph": false
+    },
+    {
+      "gpio": 13,
+      "label": "Button2",
+      "mode": "INPUT_PULLUP",
+      "type": "DIGITAL",
+      "initial_state": "",
+      "graph": false
+    },
+    {
+      "gpio": 34,
+      "label": "Button3",
+      "mode": "INPUT_PULLUP",
+      "type": "DIGITAL",
+      "initial_state": "",
+      "graph": false
+    },
+    {
+      "gpio": 21,
+      "label": "Led1",
+      "mode": "OUTPUT",
+      "type": "DIGITAL",
+      "initial_state": "LOW",
+      "graph": false
+    },
+    {
+      "gpio": 4,
+      "label": "Led2",
+      "mode": "OUTPUT",
+      "type": "DIGITAL",
+      "initial_state": "LOW",
+      "graph": false
+    },
+    {
+      "gpio": 15,
+      "label": "Led3",
+      "mode": "OUTPUT",
+      "type": "DIGITAL",
+      "initial_state": "LOW",
+      "graph": false
+    }
+  ]
+}

--- a/src/BasicMode.h
+++ b/src/BasicMode.h
@@ -1,0 +1,122 @@
+#pragma once
+
+#include <Arduino.h>
+#include "api/devices/Buzzer.h"
+#include "api/devices/sensors/Pushbtn.h" // For Sensor::Pushbtn
+#include "api/Esp32.h" // For Esp32::DEVICE_NAME
+
+namespace BasicMode {
+
+// Define the GPIO pins based on user input
+const int BUTTON1_PIN = 12;
+const int BUTTON2_PIN = 13;
+const int BUTTON3_PIN = 34;
+
+const int LED1_PIN = 21;
+const int LED2_PIN = 4;
+const int LED3_PIN = 15;
+
+// Frequencies and durations for buzzer sounds
+const unsigned int SOUND1_FREQ = 1000;
+const unsigned int SOUND1_DUR = 200;
+const unsigned int SOUND2_FREQ = 1500;
+const unsigned int SOUND2_DUR = 200;
+const unsigned int SOUND3_FREQ = 2000;
+const unsigned int SOUND3_DUR = 200;
+const unsigned int SHUTDOWN_SOUND_FREQ = 500;
+const unsigned int SHUTDOWN_SOUND_DUR = 100;
+
+class BasicModeImpl {
+public:
+    BasicModeImpl() : led1_state_(false), led2_state_(false), led3_state_(false) {
+        // Constructor
+    }
+
+    void setup() {
+        // The actual pin mode configuration (INPUT_PULLUP, OUTPUT)
+        // is expected to be done by Esp32::loadAndApplyIOConfig()
+        // based on data/io_config.json.
+
+        // Setup Pushbutton objects
+        // ISensor::setup(const char* name, const String& device_name, int pin_id, bool inverted = false, bool is_interrupt = true, int channel = 0, int address = 0);
+        // For Pushbtn, is_interrupt is true by default. inverted might depend on wiring, true if LOW means pressed.
+        // Since we are using INPUT_PULLUP, a press will result in a LOW signal.
+        // The Pushbtn class message logic `ISensor::message(!state_)` handles this inversion for messages.
+        // If getState() is used directly, it will return true for LOW if not inverted in setup, or if inverted=true is passed to setup.
+        // Let's assume getState() should return true on press (LOW state with INPUT_PULLUP).
+        // The Pushbtn class itself inverts the logic for the message it returns.
+        // We will rely on the message from loop() or ensure getState() reflects a "pressed" state correctly.
+        // The `Sensor::Pushbtn::loopImpl` returns a message when `!state_` is true (i.e. when state_ is LOW for INPUT_PULLUP).
+
+        button1_.setup("Button1", Esp32::DEVICE_NAME, BUTTON1_PIN, true, true);
+        button2_.setup("Button2", Esp32::DEVICE_NAME, BUTTON2_PIN, true, true);
+        button3_.setup("Button3", Esp32::DEVICE_NAME, BUTTON3_PIN, true, true);
+
+        // Ensure LEDs are off initially. io_config.json should handle initial_state LOW.
+        // However, a direct digitalWrite here ensures it if io_config.json was missing or incorrect.
+        digitalWrite(LED1_PIN, LOW);
+        digitalWrite(LED2_PIN, LOW);
+        digitalWrite(LED3_PIN, LOW);
+        led1_state_ = false;
+        led2_state_ = false;
+        led3_state_ = false;
+
+        Serial.println("BasicMode: Setup complete.");
+    }
+
+    void loop() {
+        String btn1_msg = button1_.loop();
+        String btn2_msg = button2_.loop();
+        String btn3_msg = button3_.loop();
+
+        if (!btn1_msg.isEmpty()) {
+            Serial.println("BasicMode: Button 1 pressed");
+            BuzzerModule::beep(SOUND1_FREQ, SOUND1_DUR);
+            led1_state_ = !led1_state_;
+            digitalWrite(LED1_PIN, led1_state_ ? HIGH : LOW);
+            Serial.printf("BasicMode: LED 1 is now %s\n", led1_state_ ? "ON" : "OFF");
+            if (!led1_state_) { // Just turned OFF
+                BuzzerModule::beep(SHUTDOWN_SOUND_FREQ, SHUTDOWN_SOUND_DUR);
+                Serial.println("BasicMode: LED 1 shutdown sound played.");
+            }
+        }
+
+        if (!btn2_msg.isEmpty()) {
+            Serial.println("BasicMode: Button 2 pressed");
+            BuzzerModule::beep(SOUND2_FREQ, SOUND2_DUR);
+            led2_state_ = !led2_state_;
+            digitalWrite(LED2_PIN, led2_state_ ? HIGH : LOW);
+            Serial.printf("BasicMode: LED 2 is now %s\n", led2_state_ ? "ON" : "OFF");
+            if (!led2_state_) { // Just turned OFF
+                BuzzerModule::beep(SHUTDOWN_SOUND_FREQ, SHUTDOWN_SOUND_DUR);
+                Serial.println("BasicMode: LED 2 shutdown sound played.");
+            }
+        }
+
+        if (!btn3_msg.isEmpty()) {
+            Serial.println("BasicMode: Button 3 pressed");
+            BuzzerModule::beep(SOUND3_FREQ, SOUND3_DUR);
+            led3_state_ = !led3_state_;
+            digitalWrite(LED3_PIN, led3_state_ ? HIGH : LOW);
+            Serial.printf("BasicMode: LED 3 is now %s\n", led3_state_ ? "ON" : "OFF");
+            if (!led3_state_) { // Just turned OFF
+                BuzzerModule::beep(SHUTDOWN_SOUND_FREQ, SHUTDOWN_SOUND_DUR);
+                Serial.println("BasicMode: LED 3 shutdown sound played.");
+            }
+        }
+    }
+
+private:
+    Sensor::Pushbtn button1_;
+    Sensor::Pushbtn button2_;
+    Sensor::Pushbtn button3_;
+
+    bool led1_state_;
+    bool led2_state_;
+    bool led3_state_;
+};
+
+// Global instance of BasicModeImpl
+BasicModeImpl basicMode;
+
+} // namespace BasicMode

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,7 @@
 #define VERBOSE
-#define HOCKEY
+//#define HOCKEY
 //#define BOAT
+#define BASIC_MODE
 
 #include <Arduino.h>
 #include "SystemState.h" // Added for SYS_state enum
@@ -17,6 +18,10 @@
 
 #ifdef HOCKEY  
     #include "Hockey.h"
+#endif
+
+#ifdef BASIC_MODE
+    #include "BasicMode.h"
 #endif
 
 const char* ver = "v1:7 ";
@@ -198,6 +203,10 @@ void loop()
             hockey.setup();
 #endif
 
+#ifdef BASIC_MODE
+        BasicMode::basicMode.setup();
+#endif
+
             Serial.println("SENSORS & ALARMLib CONFIG done");
             set_current_system_state(SYS_state::HEATUP); // Reverted to original setter
             break;
@@ -236,6 +245,10 @@ void loop()
 #ifdef HOCKEY  
             hockey.loop();
 #endif     
+
+#ifdef BASIC_MODE
+        BasicMode::basicMode.loop();
+#endif
             
 #ifdef BOAT  
             boat.loop();


### PR DESCRIPTION
I've added a new 'Basic Mode' to the ESP32 application. This mode allows interaction via three pushbuttons, each controlling an LED and a distinct buzzer sound.

Key features:
-   Button 1 (GPIO 12): Toggles LED 1 (GPIO 21) and plays sound 1.
-   Button 2 (GPIO 13): Toggles LED 2 (GPIO 4) and plays sound 2.
-   Button 3 (GPIO 34): Toggles LED 3 (GPIO 15) and plays sound 3.
-   A shutdown sound is played when an LED is turned off by a subsequent button press.
-   LED and button pins are configured via `data/io_config.json`.
-   Uses `Sensor::Pushbtn` for debounced button inputs.
-   Integrates with the existing mode selection in `main.cpp`.
-   Resolved potential pin conflict by assigning LED2 to GPIO 4, keeping default buzzer pin (GPIO 14) free.

New files:
-   `src/BasicMode.h`: Contains the implementation for the basic mode.
-   `data/io_config.json`: Provides pin configurations for the new mode (created if not existing).

Modified files:
-   `src/main.cpp`: Integrated the basic mode selection and calls.