### PR TITLE
feat: Add web front-end for Basic Mode

### DIFF
--- a/data/basic_mode/basic_mode.js
+++ b/data/basic_mode/basic_mode.js
@@ -1,0 +1,47 @@
+document.addEventListener('DOMContentLoaded', function() {
+    const led1StatusElement = document.getElementById('led1_status');
+    const led2StatusElement = document.getElementById('led2_status');
+    const led3StatusElement = document.getElementById('led3_status');
+
+    function updateLedStatus(ledElement, isOn) {
+        if (ledElement) {
+            if (isOn) {
+                ledElement.classList.add('led-on');
+                ledElement.classList.remove('led-off'); // Optional: if you have a specific led-off class
+            } else {
+                ledElement.classList.remove('led-on');
+                ledElement.classList.add('led-off'); // Optional: if you have a specific led-off class
+            }
+        }
+    }
+
+    function fetchLedStates() {
+        fetch('/api/basicmode/status')
+            .then(response => {
+                if (!response.ok) {
+                    throw new Error('Network response was not ok: ' + response.statusText);
+                }
+                return response.json();
+            })
+            .then(data => {
+                if (data) {
+                    updateLedStatus(led1StatusElement, data.led1);
+                    updateLedStatus(led2StatusElement, data.led2);
+                    updateLedStatus(led3StatusElement, data.led3);
+                }
+            })
+            .catch(error => {
+                console.error('Error fetching LED states:', error);
+                // Optionally, indicate error on the page, e.g., grey out LEDs
+                if (led1StatusElement) updateLedStatus(led1StatusElement, false); // Default to off on error
+                if (led2StatusElement) updateLedStatus(led2StatusElement, false);
+                if (led3StatusElement) updateLedStatus(led3StatusElement, false);
+            });
+    }
+
+    // Fetch initial state
+    fetchLedStates();
+
+    // Set interval to fetch states periodically (e.g., every 2 seconds)
+    setInterval(fetchLedStates, 2000); // 2000 milliseconds = 2 seconds
+});

--- a/data/basic_mode/index.html
+++ b/data/basic_mode/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Basic Mode Control</title>
+    <link rel="stylesheet" href="../colors.css">
+    <link rel="stylesheet" href="../esp32.css">
+    <link rel="stylesheet" href="../utilities.css">
+    <style>
+        .button-placeholder {
+            padding: 10px 20px;
+            border: 1px solid #ccc;
+            background-color: #f0f0f0;
+            margin: 10px;
+            display: inline-block;
+            border-radius: 5px;
+        }
+        .led-status {
+            width: 50px;
+            height: 50px;
+            border: 1px solid #000;
+            margin: 10px;
+            display: inline-block;
+            border-radius: 50%; /* Make it circular */
+            background-color: #666; /* Default to OFF color (grey) */
+        }
+        .led-on {
+            background-color: #00ff00; /* Green for ON */
+        }
+        .led-off {
+            background-color: #ff0000; /* Red for OFF - or use grey/default */
+        }
+        .container {
+            padding: 20px;
+        }
+        .control-group {
+            margin-bottom: 20px;
+            padding: 10px;
+            border: 1px solid #eee;
+            border-radius: 5px;
+        }
+        h2 {
+            margin-top: 0;
+        }
+    </style>
+</head>
+<body>
+    <header>
+        <!-- Placeholder for topMenu, assuming it's injected by topMenu.js -->
+        <div id="topMenu"></div>
+    </header>
+
+    <div class="container">
+        <h1>Basic Mode Status</h1>
+
+        <div class="control-group">
+            <h2>Button 1 / LED 1 (GPIO 21)</h2>
+            <div class="button-placeholder">Physical Button 1</div>
+            <div class="led-status" id="led1_status"></div>
+        </div>
+
+        <div class="control-group">
+            <h2>Button 2 / LED 2 (GPIO 4)</h2>
+            <div class="button-placeholder">Physical Button 2</div>
+            <div class="led-status" id="led2_status"></div>
+        </div>
+
+        <div class="control-group">
+            <h2>Button 3 / LED 3 (GPIO 15)</h2>
+            <div class="button-placeholder">Physical Button 3</div>
+            <div class="led-status" id="led3_status"></div>
+        </div>
+    </div>
+
+    <script src="../components/topMenu.js"></script>
+    <script src="basic_mode.js"></script>
+</body>
+</html>

--- a/data/components/topMenu.js
+++ b/data/components/topMenu.js
@@ -17,6 +17,7 @@ class Header extends HTMLElement {
                             <a class=" " id="hockey-link" href="hockey/Scoreboard.html">Hockey</a>
                             <a class=" " id="boat-link" href="boat/index.html">Boat</a>
                             <a class=" " id="tides-link" href="tides.html">Tides</a>
+                            <a class=" " id="basicmode-link" href="/basic_mode/">Basic Mode</a>
                         </div>
                     </div>
                     <a  class="" id="mqtt-link" href="mqtt.html">MQTTViewer</a>

--- a/src/BasicMode.h
+++ b/src/BasicMode.h
@@ -106,6 +106,10 @@ public:
         }
     }
 
+    bool getLed1State() const { return led1_state_; }
+    bool getLed2State() const { return led2_state_; }
+    bool getLed3State() const { return led3_state_; }
+
 private:
     Sensor::Pushbtn button1_;
     Sensor::Pushbtn button2_;

--- a/src/www.h
+++ b/src/www.h
@@ -14,6 +14,10 @@ Add to platformio.ini:
 #include "api/JsonTools.h" // Added for JsonTools::getJsonString
 #include "Hockey.h"
 
+#ifdef BASIC_MODE // Assuming BASIC_MODE is defined in main.cpp or a config
+#include "BasicMode.h"
+#endif
+
 
 
 namespace www
@@ -306,6 +310,31 @@ namespace www
             } else {
                 request->send(400, "application/json", "{\"status\":\"error\", \"message\":\"Missing 'gpio' parameter.\"}");
             }
+        });
+
+        server.on("/api/basicmode/status", HTTP_GET, [](AsyncWebServerRequest *request){
+            #ifdef BASIC_MODE
+                JsonDocument statusDoc;
+                // Placeholder for actual getter calls - these will be implemented in Step 5
+                // bool led1_st = BasicMode::basicMode.getLed1State();
+                // bool led2_st = BasicMode::basicMode.getLed2State();
+                // bool led3_st = BasicMode::basicMode.getLed3State();
+
+                // For now, using placeholder values until getters are ready
+                // In a real scenario, if BasicMode isn't active, this endpoint might error or return default false.
+                // However, BASIC_MODE ifdef should prevent access if mode isn't compiled.
+                statusDoc["led1"] = BasicMode::basicMode.getLed1State(); // Assumes getter exists
+                statusDoc["led2"] = BasicMode::basicMode.getLed2State(); // Assumes getter exists
+                statusDoc["led3"] = BasicMode::basicMode.getLed3State(); // Assumes getter exists
+
+                String jsonResponse;
+                serializeJson(statusDoc, jsonResponse); // Using serializeJson directly
+                request->send(200, "application/json", jsonResponse);
+            #else
+                // If BASIC_MODE is not defined, this endpoint theoretically shouldn't be hit
+                // if the front-end is also conditional. But as a fallback:
+                request->send(404, "text/plain", "Basic Mode not active");
+            #endif
         });
 
         // General config endpoint (ensure it doesn't conflict if path is similar)


### PR DESCRIPTION
Implements an HTML front-end for the Basic Mode, allowing you to view the status of the mode's LEDs in real-time.

Key changes:
-   Created `data/basic_mode/index.html`: A new web page that displays placeholders for the three physical buttons and visual indicators for the three LEDs.
-   Created `data/basic_mode/basic_mode.js`: JavaScript that polls an API endpoint (`/api/basicmode/status`) every 2 seconds to fetch the current LED states and updates the HTML page dynamically.
-   Modified `src/www.h`: Added the `/api/basicmode/status` endpoint, which returns a JSON object with the current states of the three LEDs (e.g., `{"led1": true, "led2": false, "led3": true}`).
-   Modified `data/components/topMenu.js`: Added a "Basic Mode" link to the "Web Apps" dropdown in the main navigation menu, pointing to the new Basic Mode page.
-   Modified `src/BasicMode.h`: Added public getter methods (`getLed1State`, `getLed2State`, `getLed3State`) to the `BasicModeImpl` class to allow the web server to retrieve the current LED states.

This provides a user interface for monitoring the Basic Mode's operation via a web browser.