### PR TITLE
I've made a fix to increase the JsonDocument capacity for parsing `io…

### DIFF
--- a/src/api/Esp32.cpp
+++ b/src/api/Esp32.cpp
@@ -463,12 +463,16 @@ namespace Esp32 {
             Serial.printf("Esp32: Loading I/O config from %s\n", Esp32::CONFIG_IO_FILENAME.c_str());
             String file_content = Storage::readFile(Esp32::CONFIG_IO_FILENAME);
             if (file_content.length() > 0) {
-                JsonDocument doc; // ArduinoJson V7 uses dynamic allocation by default
+                StaticJsonDocument<2048> doc;
                 DeserializationError error = deserializeJson(doc, file_content);
                 if (!error) {
                     Esp32::applyIOConfiguration(doc);
                 } else {
-                    Serial.printf("Esp32: Failed to parse %s - %s. Applying no I/O config from file.\n", Esp32::CONFIG_IO_FILENAME.c_str(), error.c_str());
+                    Serial.print(F("Esp32: Failed to parse "));
+                    Serial.print(Esp32::CONFIG_IO_FILENAME);
+                    Serial.print(F(" - Error: "));
+                    Serial.println(error.c_str()); // Print the actual error code string
+                    Serial.println(F("Applying no I/O config from file."));
                 }
             } else {
                 Serial.printf("Esp32: Failed to read %s or file is empty. Applying no I/O config from file.\n", Esp32::CONFIG_IO_FILENAME.c_str());


### PR DESCRIPTION
…_config.json`.

In `Esp32.cpp`, I modified `Esp32::loadAndApplyIOConfig()` to use a `StaticJsonDocument<2048>` instead of a default (dynamic) `JsonDocument`. This gives us a larger, fixed-size buffer for parsing `io_config.json`, which should address potential `NoMemory` errors during deserialization – I suspected that was the cause of the "'io_pins' is missing" error you were seeing.

I've also improved the error logging so that if parsing still fails, the specific `DeserializationError` code from ArduinoJson will be printed.