### PR TITLE
debug: Add enhanced debugging for io_config.json parsing

### DIFF
--- a/src/api/Esp32.cpp
+++ b/src/api/Esp32.cpp
@@ -465,6 +465,26 @@ namespace Esp32 {
             if (file_content.length() > 0) {
                 StaticJsonDocument<2048> doc;
                 DeserializationError error = deserializeJson(doc, file_content);
+
+        Serial.print(F("Esp32: deserializeJson error code: "));
+        Serial.println(error.c_str()); // Print the error code regardless
+
+        if (doc.isNull()) {
+            Serial.println(F("Esp32: Parsed JsonDocument is null!"));
+        } else {
+            Serial.println(F("Esp32: Parsed JsonDocument is NOT null."));
+            Serial.print(F("Esp32: doc.containsKey(\"io_pins\"): "));
+            Serial.println(doc.containsKey("io_pins") ? "true" : "false");
+            if (doc.containsKey("io_pins")) {
+                Serial.print(F("Esp32: doc[\"io_pins\"].is<JsonArray>(): "));
+                Serial.println(doc["io_pins"].is<JsonArray>() ? "true" : "false");
+            }
+            String serializedDoc;
+            serializeJsonPretty(doc, serializedDoc); // Using Pretty for readability
+            Serial.println(F("Esp32: Content of parsed 'doc' after deserializeJson:"));
+            Serial.println(serializedDoc);
+        }
+
                 if (!error) {
                     Esp32::applyIOConfiguration(doc);
                 } else {


### PR DESCRIPTION
Modifies Esp32::loadAndApplyIOConfig() in Esp32.cpp to include extensive serial printing immediately after deserializeJson(). This includes:
- The explicit DeserializationError code.
- Checks for doc.isNull().
- Checks for doc.containsKey("io_pins") and if it's an array.
- A pretty-print of the serialized JsonDocument post-parsing.

This is intended to provide detailed diagnostics for the persistent issue where "io_pins" is reported as missing or not an array by the applyIOConfiguration function, despite deserializeJson not previously indicating a fatal error.