### PR TITLE
To help debug, I've added some extra logging to the `applyIOConfigura…

### DIFF
--- a/src/api/Esp32.cpp
+++ b/src/api/Esp32.cpp
@@ -370,6 +370,19 @@ namespace Esp32 {
 
     // I/O Configuration Core Logic Implementations
     void applyIOConfiguration(const JsonDocument& doc) {
+    Serial.println(F("Esp32: Entered applyIOConfiguration. Received doc content:"));
+    String receivedDocStr;
+    serializeJsonPretty(doc, receivedDocStr); // Or serializeJson(doc, receivedDocStr);
+    Serial.println(receivedDocStr);
+
+    Serial.print(F("Esp32: applyIOConfiguration - !doc[\"io_pins\"].isNull(): "));
+    Serial.println(!doc["io_pins"].isNull() ? "true" : "false");
+    if(!doc["io_pins"].isNull()){ // Corrected the key string here
+        Serial.print(F("Esp32: applyIOConfiguration - doc[\"io_pins\"].is<JsonArray>(): "));
+        Serial.println(doc["io_pins"].is<JsonArray>() ? "true" : "false");
+    } else {
+        Serial.println(F("Esp32: applyIOConfiguration - doc[\"io_pins\"] is null."));
+    }
         Esp32::configured_pins.clear();
         // JsonArray io_pins_array = doc["io_pins"].as<JsonArray>(); // V6
         JsonVariantConst io_pins_variant = doc["io_pins"]; // V7 style for const JsonDocument&


### PR DESCRIPTION
…tion` function.

Specifically, I've modified `Esp32::applyIOConfiguration()` in `Esp32.cpp` so it will now print the content of the received `JsonDocument` right when the function starts. It will also immediately check if the "io_pins" key exists and what its type is.

This should help us figure out why the `JsonDocument`, which seems correct when it's in the `loadAndApplyIOConfig` function, is causing an "'io_pins' is missing" error inside `applyIOConfiguration`. This will make it clearer if the document's state is changing when it's passed as a parameter to the function.