### PR TITLE
fix: Correct declaration of applyIOConfiguration in Esp32.h

### DIFF
--- a/src/api/Esp32.h
+++ b/src/api/Esp32.h
@@ -61,7 +61,7 @@ namespace Esp32 {
     extern std::vector<IO_Pin_Detail> configured_pins;
 
     // I/O Configuration Core Logic
-    void applyIOConfiguration(const JsonDocument& doc); // Pass JsonDocument by const reference
+    void applyIOConfiguration(const String& jsonConfigString); // Pass JsonDocument by const reference
     bool saveAndApplyIOConfiguration(const JsonDocument& doc); // Pass JsonDocument by const reference
     void loadAndApplyIOConfig();
     String getIOStatusJsonString(); // Added declaration


### PR DESCRIPTION
Updates the declaration of Esp32::applyIOConfiguration in src/api/Esp32.h to match its definition in Esp32.cpp. The function parameter is changed from 'const JsonDocument& doc' to 'const String& jsonConfigString'.

This fixes a compilation error where the definition in the .cpp file did not match any declaration in the header file after a previous refactoring of applyIOConfiguration to accept a JSON string.