### PR TITLE
fix: Correct definition of applyIOConfiguration in Esp32.cpp

### DIFF
--- a/src/api/Esp32.cpp
+++ b/src/api/Esp32.cpp
@@ -369,7 +369,7 @@ namespace Esp32 {
     }
 
     // I/O Configuration Core Logic Implementations
-    void Esp32::applyIOConfiguration(const String& jsonConfigString) {
+    void applyIOConfiguration(const String& jsonConfigString) {
         Esp32::configured_pins.clear(); // Ensure this is at the very top
 
         JsonDocument parsedDocInApply;


### PR DESCRIPTION
Removes the redundant 'Esp32::' namespace qualifier from the definition of the 'applyIOConfiguration' function in Esp32.cpp. The function definition is already within the 'namespace Esp32 { ... }' block, so the explicit qualifier was incorrect and caused a compilation error ("explicit qualification in declaration").

This change ensures the definition syntax is correct and should allow your project to compile successfully with the recent refactoring of this function (which now accepts a String).