### PR TITLE
Alright, I've made some changes to reduce log verbosity and increase …

### DIFF
--- a/src/BasicMode.h
+++ b/src/BasicMode.h
@@ -68,16 +68,16 @@ public:
     }
 
     void loop() {
-        Serial.println("BasicModeImpl::loop() executing");
+        // Serial.println("BasicModeImpl::loop() executing");
 
         String btn1_msg = button1_.loop();
-        Serial.print("btn1_msg: '"); Serial.print(btn1_msg); Serial.println("'");
+        // Serial.print("btn1_msg: '"); Serial.print(btn1_msg); Serial.println("'");
 
         String btn2_msg = button2_.loop();
-        Serial.print("btn2_msg: '"); Serial.print(btn2_msg); Serial.println("'");
+        // Serial.print("btn2_msg: '"); Serial.print(btn2_msg); Serial.println("'");
 
         String btn3_msg = button3_.loop();
-        Serial.print("btn3_msg: '"); Serial.print(btn3_msg); Serial.println("'");
+        // Serial.print("btn3_msg: '"); Serial.print(btn3_msg); Serial.println("'");
 
         if (!btn1_msg.isEmpty()) {
             Serial.println("BasicMode: Button 1 event detected by BasicModeImpl");

--- a/src/api/devices/sensors/Pushbtn.h
+++ b/src/api/devices/sensors/Pushbtn.h
@@ -2,7 +2,7 @@
 
 #include "ISensor.h"
 
-#define DEBOUNCETIME 10
+#define DEBOUNCETIME 50
 
 
 namespace Sensor


### PR DESCRIPTION
…the button debounce time.

Here's what I did:

1.  In `src/BasicMode.h` (specifically within `BasicModeImpl::loop()`):
    *   I've commented out the chatty `Serial.print` statements that were firing off on every loop. You'll still see logs for actual debounced button events, but things should be much quieter on the console now.

2.  Over in `src/api/devices/sensors/Pushbtn.h`:
    *   I've bumped the `DEBOUNCETIME` macro from 10 to 50 milliseconds. This should help make the physical button presses more reliable and cut down on any glitchy behavior like multiple events firing for a single press or issues with sound and LED synchronization.